### PR TITLE
Save and restore state

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -65,8 +65,7 @@ pub struct Config {
 
     /// Directory to store app state.
     ///
-    /// Defaults to "/tmp"
-    #[serde(deserialize_with = "config_de::dir_path")]
+    /// Defaults to "/media/data"
     pub storage_dir: PathBuf,
 
     pub away_mode: AwayConfig,
@@ -117,7 +116,7 @@ impl Default for Config {
             temp_deadband: 0.6,
             temp_overrun: 0.4,
             min_off_time: Duration::from_mins(5),
-            storage_dir: PathBuf::from("/tmp"),
+            storage_dir: PathBuf::from("/media/data"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,10 +63,10 @@ pub struct Config {
     #[serde(deserialize_with = "config_de::duration")]
     pub min_off_time: Duration,
 
-    /// Path to file where retherm will store app state.
+    /// Directory to store app state.
     ///
-    /// Defaults to "/media/data/rether.state.toml"
-    pub state_file_path: PathBuf,
+    /// Defaults to "/media/data"
+    pub storage_dir: PathBuf,
 
     pub away_mode: AwayConfig,
     pub backplate: BackplateConfig,
@@ -116,7 +116,7 @@ impl Default for Config {
             temp_deadband: 0.6,
             temp_overrun: 0.4,
             min_off_time: Duration::from_mins(5),
-            state_file_path: PathBuf::from("/media/data/retherm.state.toml"),
+            storage_dir: PathBuf::from("/media/data"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{fs, path::Path, time::Duration};
+use std::{fs, path::{Path, PathBuf}, time::Duration};
 
 use anyhow::Result;
 use serde::Deserialize;
@@ -62,6 +62,12 @@ pub struct Config {
     /// Defaults to "5m"
     #[serde(deserialize_with = "config_de::duration")]
     pub min_off_time: Duration,
+
+    /// Directory to store app state.
+    ///
+    /// Defaults to "/tmp"
+    #[serde(deserialize_with = "config_de::dir_path")]
+    pub storage_dir: PathBuf,
 
     pub away_mode: AwayConfig,
     pub backplate: BackplateConfig,
@@ -111,6 +117,7 @@ impl Default for Config {
             temp_deadband: 0.6,
             temp_overrun: 0.4,
             min_off_time: Duration::from_mins(5),
+            storage_dir: PathBuf::from("/tmp"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,10 +63,10 @@ pub struct Config {
     #[serde(deserialize_with = "config_de::duration")]
     pub min_off_time: Duration,
 
-    /// Directory to store app state.
+    /// Path to file where retherm will store app state.
     ///
-    /// Defaults to "/media/data"
-    pub storage_dir: PathBuf,
+    /// Defaults to "/media/data/rether.state.toml"
+    pub state_file_path: PathBuf,
 
     pub away_mode: AwayConfig,
     pub backplate: BackplateConfig,
@@ -116,7 +116,7 @@ impl Default for Config {
             temp_deadband: 0.6,
             temp_overrun: 0.4,
             min_off_time: Duration::from_mins(5),
-            storage_dir: PathBuf::from("/media/data"),
+            state_file_path: PathBuf::from("/media/data/retherm.state.toml"),
         }
     }
 }

--- a/src/config/config_de.rs
+++ b/src/config/config_de.rs
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 use chrono::NaiveTime;
 use serde::{Deserializer, de::{self, Visitor}};
@@ -93,4 +93,31 @@ pub fn time_of_day<'de, D>(deserializer: D) -> Result<NaiveTime, D::Error>
     }
 
     deserializer.deserialize_any(TimeOfDayVisitor)
+}
+
+pub fn dir_path<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
+    where D: Deserializer<'de>
+{
+    struct PathBufVisitor;
+
+    impl<'de> Visitor<'de> for PathBufVisitor {
+        type Value = PathBuf;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("path to existing directory")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where E: de::Error
+        {
+            let val = PathBuf::from(v);
+            if !val.is_dir() {
+                return Err(E::custom(format!("{:?} is not an existing directory", val)));
+            }
+
+            Ok(val)
+        }
+    }
+
+    deserializer.deserialize_any(PathBufVisitor)
 }

--- a/src/config/config_de.rs
+++ b/src/config/config_de.rs
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
 use chrono::NaiveTime;
 use serde::{Deserializer, de::{self, Visitor}};
@@ -93,31 +93,4 @@ pub fn time_of_day<'de, D>(deserializer: D) -> Result<NaiveTime, D::Error>
     }
 
     deserializer.deserialize_any(TimeOfDayVisitor)
-}
-
-pub fn dir_path<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
-    where D: Deserializer<'de>
-{
-    struct PathBufVisitor;
-
-    impl<'de> Visitor<'de> for PathBufVisitor {
-        type Value = PathBuf;
-
-        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            f.write_str("path to existing directory")
-        }
-
-        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where E: de::Error
-        {
-            let val = PathBuf::from(v);
-            if !val.is_dir() {
-                return Err(E::custom(format!("{:?} is not an existing directory", val)));
-            }
-
-            Ok(val)
-        }
-    }
-
-    deserializer.deserialize_any(PathBufVisitor)
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -57,3 +57,10 @@ pub fn get_pkg_ver() -> &'static str {
 pub fn get_pkg_name() -> &'static str {
     env!("CARGO_PKG_NAME")
 }
+
+pub fn state_file_name() -> String {
+    match std::env::var("RETHERM_STATE_FILE") {
+        Ok(file_name) => file_name,
+        Err(_) => String::from("retherm.state.toml")
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
 
     let mut event_source = window::new_event_source()?;
 
-    let mut storage = storage::Storage::new(&config);
+    let mut storage = storage::Storage::new(&config)?;
     let state = storage.read_state()?;
 
     let mut state_manager = state::StateManager::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod schedule;
 mod screen;
 mod sound;
 mod state;
+mod storage;
 mod theme;
 mod timer;
 mod widgets;
@@ -77,7 +78,9 @@ fn main() -> Result<()> {
 
     let mut event_source = window::new_event_source()?;
 
-    let state = state::ThermostatState::default();
+    let mut storage = storage::Storage::new(&config);
+    let state = storage.read_state()?;
+
     let mut state_manager = state::StateManager::new(
         &config,
         state.clone(),
@@ -128,6 +131,7 @@ fn main() -> Result<()> {
         }
 
         let mut handlers: [&mut dyn EventHandler; _] = [
+            &mut storage,
             &mut state_manager,
             &mut schedule,
             &mut backplate,

--- a/src/state.rs
+++ b/src/state.rs
@@ -22,6 +22,7 @@ use anyhow::Result;
 use esphome_api::proto::{
     ClimateAction, ClimateFanMode, ClimateMode, ClimatePreset, ClimateStateResponse
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{
     config::{AwayConfig, Config},
@@ -98,7 +99,7 @@ impl From<&ThermostatState> for ClimateStateResponse {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
 pub enum HvacMode {
     Off,
     Auto,
@@ -131,7 +132,7 @@ impl From<HvacMode> for ClimateMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
 pub enum HvacAction {
     Idle,
     Heating,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{fs, path::PathBuf, sync::mpsc::{Sender, channel}, thread};
+use std::{fs, path::{Path, PathBuf}, sync::mpsc::{Sender, channel}, thread};
 
 use anyhow::{Result, anyhow};
 use log::{info, warn};
@@ -24,32 +24,31 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::{
     config::Config,
+    env,
     events::{Event, EventHandler},
     state::{HvacMode, ThermostatState}
 };
 
 pub struct Storage {
-    state_storage: StorageBackend,
-    write_thread: Sender<ThermostatState>
+    backend: StorageBackend,
+    write_thread: Sender<Storable>
 }
 
 impl Storage {
     pub fn new(config: &Config) -> Result<Self> {
-        let state_dir = config.state_file_path.parent()
-            .ok_or(anyhow!("Unable to get parent of state file path"))?;
-        if !state_dir.is_dir() {
-            Err(anyhow!("Directory {:?} does not exist", state_dir))
+        if !config.storage_dir.is_dir() {
+            Err(anyhow!("Directory {:?} does not exist", config.storage_dir))
         } else {
-            let state_storage = StorageBackend::new(config.state_file_path.clone());
-            let write_thread = start_write_thread(state_storage.clone());
+            let backend = StorageBackend::new(config.storage_dir.clone());
+            let write_thread = start_write_thread(backend.clone());
             Ok(Self {
-                state_storage, write_thread
+                backend, write_thread
             })
         }
     }
 
     pub fn read_state(&self) -> Result<ThermostatState> {
-        let state = if let Some(state) = self.state_storage.read()? {
+        let state = if let Some(state) = self.backend.read(env::state_file_name())? {
             ThermostatState::from(&state)
         } else {
             warn!("State does not exist, using default");
@@ -62,13 +61,17 @@ impl Storage {
     }
 }
 
-fn start_write_thread(state_storage: StorageBackend) -> Sender<ThermostatState> {
-    let (tx, rx) = channel::<ThermostatState>();
+fn start_write_thread(backend: StorageBackend) -> Sender<Storable> {
+    let (tx, rx) = channel::<Storable>();
 
     thread::spawn(move || {
-        while let Ok(state) = rx.recv() {
-            let state = StoredState::from(&state);
-            state_storage.write(state).unwrap();
+        while let Ok(data) = rx.recv() {
+            match data {
+                Storable::State(state) => {
+                    let state = StoredState::from(&state);
+                    backend.write(env::state_file_name(), state).unwrap();
+                }
+            }
         }
     });
 
@@ -78,7 +81,7 @@ fn start_write_thread(state_storage: StorageBackend) -> Sender<ThermostatState> 
 impl EventHandler for Storage {
     fn handle_event(&mut self, event: &Event) -> Result<()> {
         if let Event::State(state) = event {
-            self.write_thread.send(state.clone())?;
+            self.write_thread.send(Storable::State(state.clone()))?;
         }
 
         Ok(())
@@ -89,7 +92,7 @@ impl EventHandler for Storage {
 struct StoredState {
     target_temp: f32,
     current_temp: f32,
-    mode: HvacMode
+    mode: HvacMode,
 }
 
 impl From<&ThermostatState> for StoredState {
@@ -97,7 +100,7 @@ impl From<&ThermostatState> for StoredState {
         Self {
             target_temp: value.target_temp,
             current_temp: value.current_temp,
-            mode: value.mode
+            mode: value.mode,
         }
     }
 }
@@ -113,23 +116,28 @@ impl From<&StoredState> for ThermostatState {
     }
 }
 
+enum Storable {
+    State(ThermostatState)
+}
+
 #[derive(Clone)]
 struct StorageBackend {
-    file_path: PathBuf
+    storage_dir: PathBuf
 }
 
 impl StorageBackend {
-    fn new(file_path: PathBuf) -> Self {
-        Self { file_path }
+    fn new(storage_dir: PathBuf) -> Self {
+        Self { storage_dir }
     }
 
-    fn read<T>(&self) -> Result<Option<T>>
-        where T: DeserializeOwned
+    fn read<P, T>(&self, file_name: P) -> Result<Option<T>>
+        where P: AsRef<Path>, T: DeserializeOwned
     {
-        info!("Loading file {:?}", self.file_path);
+        let file_path = self.storage_dir.join(file_name);
+        info!("Loading file {:?}", file_path.file_name());
 
-        let state = if self.file_path.is_file() {
-            let toml_src = fs::read_to_string(&self.file_path)?;
+        let state = if file_path.is_file() {
+            let toml_src = fs::read_to_string(&file_path)?;
             Some(toml::from_str(&toml_src)?)
         } else {
             None
@@ -138,16 +146,25 @@ impl StorageBackend {
         Ok(state)
     }
 
-    fn write<T>(&self, value: T) -> Result<()>
-        where T: Serialize + DeserializeOwned + PartialEq
+    fn write<P, T>(&self, file_name: P, value: T) -> Result<()>
+        where P: AsRef<Path>, T: Serialize + DeserializeOwned + PartialEq
     {
-        if let Some(existing) = self.read::<T>()? {
-            if existing != value {
-                info!("Saving to file {:?}", self.file_path);
+        let file_path = self.storage_dir.join(file_name.as_ref());
 
-                let toml_src = toml::to_string(&value)?;
-                fs::write(&self.file_path, toml_src)?;
+        // In an attempt to avoid excessive NAND writes,
+        // serialize and write if data has changed.
+        let toml_src = match self.read::<P, T>(file_name)? {
+            None => Some(toml::to_string(&value)?),
+            Some(existing) if existing != value => {
+                Some(toml::to_string(&value)?)
             }
+            _ => None
+        };
+
+        if let Some(toml_src) = toml_src {
+            info!("Saving to file {:?}", file_path);
+
+            fs::write(&file_path, toml_src)?;
         }
 
         Ok(())

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,99 @@
+/*
+ * ReTherm - Home Assistant native interface for Gen2 Nest thermostat
+ * Copyright (C) 2026 Josh Kropf <josh@slashdev.ca>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use std::{fs, path::PathBuf};
+
+use anyhow::Result;
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+
+use crate::{config::Config, events::{Event, EventHandler}, state::{HvacMode, ThermostatState}};
+
+pub struct Storage {
+    state_file_path: PathBuf
+}
+
+impl Storage {
+    pub fn new(config: &Config) -> Self {
+        Self {
+            state_file_path: config.storage_dir.join("retherm_state.toml")
+        }
+    }
+
+    pub fn read_state(&self) -> Result<ThermostatState> {
+        info!("Loading state from {:?}", self.state_file_path);
+        let state = if self.state_file_path.is_file() {
+            let toml_src = fs::read_to_string(&self.state_file_path)?;
+            let state_storage:StoredState = toml::from_str(&toml_src)?;
+            ThermostatState::from(&state_storage)
+        } else {
+            warn!("State does not exist, using default");
+            ThermostatState::default()
+        };
+
+        info!("Loaded state {:?}", state);
+
+        Ok(state)
+    }
+
+    fn save_state(&self, state: &ThermostatState) -> Result<()> {
+        info!("Saving state to {:?}", self.state_file_path);
+        let state_storage = StoredState::from(state);
+        let toml_src = toml::to_string(&state_storage)?;
+        fs::write(&self.state_file_path, toml_src)?;
+        Ok(())
+    }
+}
+
+impl EventHandler for Storage {
+    fn handle_event(&mut self, event: &Event) -> Result<()> {
+        if let Event::State(state) = event {
+            self.save_state(&state)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct StoredState {
+    target_temp: f32,
+    current_temp: f32,
+    mode: HvacMode
+}
+
+impl From<&ThermostatState> for StoredState {
+    fn from(value: &ThermostatState) -> Self {
+        Self {
+            target_temp: value.target_temp,
+            current_temp: value.current_temp,
+            mode: value.mode
+        }
+    }
+}
+
+impl From<&StoredState> for ThermostatState {
+    fn from(value: &StoredState) -> Self {
+        Self {
+            target_temp: value.target_temp,
+            current_temp: value.current_temp,
+            mode: value.mode,
+            ..Default::default()
+        }
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -16,11 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{fs, path::PathBuf};
+use std::{fs, path::PathBuf, sync::mpsc::{Sender, channel}, thread};
 
 use anyhow::{Result, anyhow};
 use log::{info, warn};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::{
     config::Config,
@@ -29,7 +29,8 @@ use crate::{
 };
 
 pub struct Storage {
-    state_file_path: PathBuf
+    state_storage: StorageBackend,
+    write_thread: Sender<ThermostatState>
 }
 
 impl Storage {
@@ -39,18 +40,17 @@ impl Storage {
         if !state_dir.is_dir() {
             Err(anyhow!("Directory {:?} does not exist", state_dir))
         } else {
+            let state_storage = StorageBackend::new(config.state_file_path.clone());
+            let write_thread = start_write_thread(state_storage.clone());
             Ok(Self {
-                state_file_path: config.state_file_path.clone()
+                state_storage, write_thread
             })
         }
     }
 
     pub fn read_state(&self) -> Result<ThermostatState> {
-        info!("Loading state from {:?}", self.state_file_path);
-        let state = if self.state_file_path.is_file() {
-            let toml_src = fs::read_to_string(&self.state_file_path)?;
-            let state_storage:StoredState = toml::from_str(&toml_src)?;
-            ThermostatState::from(&state_storage)
+        let state = if let Some(state) = self.state_storage.read()? {
+            ThermostatState::from(&state)
         } else {
             warn!("State does not exist, using default");
             ThermostatState::default()
@@ -60,27 +60,32 @@ impl Storage {
 
         Ok(state)
     }
+}
 
-    fn save_state(&self, state: &ThermostatState) -> Result<()> {
-        info!("Saving state to {:?}", self.state_file_path);
-        let state_storage = StoredState::from(state);
-        let toml_src = toml::to_string(&state_storage)?;
-        fs::write(&self.state_file_path, toml_src)?;
-        Ok(())
-    }
+fn start_write_thread(state_storage: StorageBackend) -> Sender<ThermostatState> {
+    let (tx, rx) = channel::<ThermostatState>();
+
+    thread::spawn(move || {
+        while let Ok(state) = rx.recv() {
+            let state = StoredState::from(&state);
+            state_storage.write(state).unwrap();
+        }
+    });
+
+    tx
 }
 
 impl EventHandler for Storage {
     fn handle_event(&mut self, event: &Event) -> Result<()> {
         if let Event::State(state) = event {
-            self.save_state(&state)?;
+            self.write_thread.send(state.clone())?;
         }
 
         Ok(())
     }
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, PartialEq)]
 struct StoredState {
     target_temp: f32,
     current_temp: f32,
@@ -105,5 +110,46 @@ impl From<&StoredState> for ThermostatState {
             mode: value.mode,
             ..Default::default()
         }
+    }
+}
+
+#[derive(Clone)]
+struct StorageBackend {
+    file_path: PathBuf
+}
+
+impl StorageBackend {
+    fn new(file_path: PathBuf) -> Self {
+        Self { file_path }
+    }
+
+    fn read<T>(&self) -> Result<Option<T>>
+        where T: DeserializeOwned
+    {
+        info!("Loading file {:?}", self.file_path);
+
+        let state = if self.file_path.is_file() {
+            let toml_src = fs::read_to_string(&self.file_path)?;
+            Some(toml::from_str(&toml_src)?)
+        } else {
+            None
+        };
+
+        Ok(state)
+    }
+
+    fn write<T>(&self, value: T) -> Result<()>
+        where T: Serialize + DeserializeOwned + PartialEq
+    {
+        if let Some(existing) = self.read::<T>()? {
+            if existing != value {
+                info!("Saving to file {:?}", self.file_path);
+
+                let toml_src = toml::to_string(&value)?;
+                fs::write(&self.file_path, toml_src)?;
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -34,11 +34,13 @@ pub struct Storage {
 
 impl Storage {
     pub fn new(config: &Config) -> Result<Self> {
-        if !config.storage_dir.is_dir() {
-            Err(anyhow!("Storage dir {:?} does not exist", config.storage_dir))
+        let state_dir = config.state_file_path.parent()
+            .ok_or(anyhow!("Unable to get parent of state file path"))?;
+        if !state_dir.is_dir() {
+            Err(anyhow!("Directory {:?} does not exist", state_dir))
         } else {
             Ok(Self {
-                state_file_path: config.storage_dir.join("retherm_state.toml")
+                state_file_path: config.state_file_path.clone()
             })
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,20 +18,28 @@
 
 use std::{fs, path::PathBuf};
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 
-use crate::{config::Config, events::{Event, EventHandler}, state::{HvacMode, ThermostatState}};
+use crate::{
+    config::Config,
+    events::{Event, EventHandler},
+    state::{HvacMode, ThermostatState}
+};
 
 pub struct Storage {
     state_file_path: PathBuf
 }
 
 impl Storage {
-    pub fn new(config: &Config) -> Self {
-        Self {
-            state_file_path: config.storage_dir.join("retherm_state.toml")
+    pub fn new(config: &Config) -> Result<Self> {
+        if !config.storage_dir.is_dir() {
+            Err(anyhow!("Storage dir {:?} does not exist", config.storage_dir))
+        } else {
+            Ok(Self {
+                state_file_path: config.storage_dir.join("retherm_state.toml")
+            })
         }
     }
 

--- a/website/content/configuration.md
+++ b/website/content/configuration.md
@@ -43,6 +43,12 @@ Minimum off time for cooling to allow AC refrigerant pressures to equalize.
 
 Defaults to "5m"
 
+## state_file_path
+
+Path to file where retherm will store app state.
+
+Defaults to "/media/data/rether.state.toml"
+
 # Away Mode
 
 ```toml

--- a/website/content/configuration.md
+++ b/website/content/configuration.md
@@ -43,11 +43,11 @@ Minimum off time for cooling to allow AC refrigerant pressures to equalize.
 
 Defaults to "5m"
 
-## state_file_path
+## storage_dir
 
-Path to file where retherm will store app state.
+Directory to store app state.
 
-Defaults to "/media/data/rether.state.toml"
+Defaults to "/media/data"
 
 # Away Mode
 


### PR DESCRIPTION
Closes #15

This saves the target temp, mode (heat, cool, off), and current temp.

* State file path `/media/data/rether.state.toml`.
* Common storage directory setting `storage_dir`, defaults to `/media/data` (partition on nest with various other files that looks like application state data).
* No setting to change state file name (didn't seem necessary)
* Environment variable `RETHERM_STATE_FILE` can be used to change it at runtime if necessary

Why is current temp saved when this is not user driven state? My thinking is I don't want the arbitrary current temp default to cause hvac switching on startup, which is likely if the target temp was saved/restored on startup.