### PR TITLE
Add Home Assistant guide and expand documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,110 @@
 # (Re)Therm
 
-(Re)store remote management of Gen2 Nest Thermostat through your existing
-Home Assistant setup.
+ReTherm is a replacement thermostat application for a rooted second-generation
+Nest Thermostat. It runs **on the thermostat itself**, drives the Nest display
+and backplate, and provides remote control to Home Assistant through an
+ESPHome Native API server.
 
-This project aims to provide a completely new UI for a rooted Gen 2 Nest
-Thermostat.
+ReTherm is not a plugin for the stock Nest application. The stock application
+must be stopped while ReTherm is running, so test the installation before
+changing anything that starts automatically at boot.
 
-## Highlevel list of features for MVP
+## How Home Assistant connects
 
-- [x] Bi-directional Home Assistant connection using esphome API
-- [ ] Automatic device discovery in Home Assistant (mDNS)
-- [x] Dial interface similar to stock Nest UI with mode select
-- [x] Away mode based on presence sensors
-- [x] Turning the HVAC system on/off to reach target temp.
-- [x] Fan mode with timer to switch off fan
-- [x] Configurable interface look/feel (separate from app config)
-- [x] Configuration file for settings such as:
-  - [x] HA related parameters (api key, device name, etc)
-  - [x] Screen brightness, auto-off timeout
-  - [x] HVAC wiring settings
-- [ ] Integrate with system wifi manager (Connman 1.29)
-- [x] Screen auto-off, wake on user input
+```text
++----------------+       ESPHome Native API        +--------------------------+
+| Home Assistant | ------------------------------> | ReTherm on the rooted Nest|
+|                |          TCP 6053               | Gen 2 thermostat          |
++----------------+                                  +--------------------------+
+```
 
-## Development Mode
+Home Assistant connects straight to ReTherm at the thermostat's IP address.
+This path does not use Google's Nest API, the stock Nest application,
+NoLongerEvil's Home Assistant integration, or MQTT. ReTherm currently does not
+implement mDNS/zeroconf discovery, so add it to Home Assistant manually by IP.
 
-Run `cargo run` to start retherm in a simulated window (uses SDL, which needs
-to be installed). Some device specific features don't work in this mode.
+ReTherm exposes one ESPHome climate entity with:
 
-## Build Requirements
+- current and target temperature;
+- `off`, `heat`, `cool`, and `fan only` modes;
+- the current HVAC action (`idle`, `heating`, `cooling`, or `fan`); and
+- `none` and `away` presets.
 
-Add target with `rustup`
+Home Assistant can change the target temperature, mode, and away preset. The
+entity ID is assigned from the configured ESPHome object/node naming, so do not
+assume a fixed entity ID.
 
-```bash
+## Install on a thermostat
+
+The complete installation guide is on the
+[documentation site](https://retherm.kropf.io/install/). In outline:
+
+1. Root the Gen 2 Nest and confirm SSH access.
+2. Copy the release binary to `/retherm/retherm` and make it executable.
+3. Install [`init.sh`](init.sh) as `/etc/init.d/retherm`.
+4. Create `/retherm/config.toml`. This file is required by the supplied init
+   script; [`config.example.toml`](config.example.toml) is a working starting
+   point.
+5. Stop the stock application with `/etc/init.d/nestlabs stop`.
+6. Start ReTherm with `/etc/init.d/retherm start`.
+7. Confirm the process is running and TCP port 6053 is listening.
+8. Add the thermostat to Home Assistant manually with the ESPHome integration.
+
+A minimal configuration is:
+
+```toml
+[home_assistant]
+friendly_name = "Hallway Nest"
+node_name = "hallway-nest"
+```
+
+All configuration values are optional, but the configuration **file** is not
+optional when using the supplied init script. By default the ESPHome server
+listens on `0.0.0.0:6053` without encryption. See
+[Configuration](https://retherm.kropf.io/configuration/) for every setting and
+[Home Assistant](https://retherm.kropf.io/home-assistant/) for optional ESPHome
+Noise encryption.
+
+To return safely to the stock Nest software:
+
+```sh
+/etc/init.d/retherm stop
+/etc/init.d/nestlabs start
+```
+
+## Add it to Home Assistant
+
+1. Start ReTherm and determine the thermostat's IP address.
+2. In Home Assistant, open **Settings → Devices & services → Add Integration →
+   ESPHome**.
+3. Enter the thermostat's IP address and port `6053` (unless `listen_addr` was
+   changed).
+4. If `encryption_key` is not set in ReTherm, leave encryption/password fields
+   blank. If it is set, enter the same key in Home Assistant.
+5. Complete the integration and test temperature and HVAC mode changes.
+
+See the [troubleshooting guide](https://retherm.kropf.io/troubleshooting/) if
+Home Assistant cannot connect or ReTherm does not start.
+
+## Development
+
+Run `cargo run` to start ReTherm in a simulated SDL window. Device-specific
+features do not work in simulation.
+
+For a device build, add the ARM target and obtain the Nest toolchain:
+
+```sh
 rustup target add armv7-unknown-linux-gnueabihf
-```
-
-Get Arm toolchain (copied from docker image; requires docker)
-
-```bash
 just get-toolchain
-```
-
-## Building & Running
-
-First; the stock app needs to be stopped.
-
-```bash
-/etc/init.d/nestlabs stop
-```
-
-Optional: start `build_recv.sh` on device and use `just push` to build,
-push to device, and restart app (uses netcat on port 51234).
-
-Or build and send manually.
-
-```bash
-# Build output at `target/armv7-unknown-linux-gnueabihf/release/retherm`
 just build
 ```
 
-## Build with Docker
+The binary is written to
+`target/armv7-unknown-linux-gnueabihf/release/retherm`. Alternatively, use
+`just build-docker` to build with Docker.
 
-If you do not want to install the build tools, you can use docker to build.
-
-```bash
-# Build output at `target/armv7-unknown-linux-gnueabihf/release/retherm`
-just build-with-docker
-```
+For development deployment, start `build_recv.sh` on the thermostat and use
+`just push` to build, send the binary with netcat on port 51234, and restart it.
 
 ## Stretch goals
 
@@ -102,3 +140,11 @@ This is the behaviour I've observed with the stock Nest app.
   (presummably until battery dies)
 * Need to look into what Nest app does; could it be as simple setting kernel
   power state?
+
+## Current limitations
+
+- No mDNS/zeroconf discovery; configure the ESPHome integration by IP.
+- No Wi-Fi configuration UI. Keep a tested way to restore the stock Nest
+  application so that network settings and SSH access remain recoverable.
+- ReTherm is intended for rooted Gen 2 hardware and is not a Google Nest cloud
+  integration.

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,14 @@
+# The supplied init script loads this file from /retherm/config.toml.
+# Every setting is optional; uncomment values only when you want to override a
+# default.
+
+[home_assistant]
+friendly_name = "Hallway Nest"
+node_name = "hallway-nest"
+
+# Default ESPHome Native API listen address:
+# listen_addr = "0.0.0.0:6053"
+
+# Optional ESPHome Noise encryption. This must be a base64-encoded 32-byte key,
+# and the same key must be entered in Home Assistant:
+# encryption_key = "<base64 ESPHome Noise PSK>"

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,7 +57,9 @@ pub struct Config {
     /// Defaults to 0.4
     pub temp_overrun: f32,
 
-    /// Minimum off time for cooling to allow AC refrigerant pressures to equalize.
+    /// Minimum idle time before ReTherm energizes a new HVAC action. This also
+    /// provides compressor protection by allowing refrigerant pressures to
+    /// equalize.
     ///
     /// Defaults to "5m"
     #[serde(deserialize_with = "config_de::duration")]
@@ -138,15 +140,17 @@ impl Default for Config {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(default)]
 pub struct HomeAssistantConfig {
-    /// Object ID used internall by home assistant.
-    /// Defaults to "climage.{node_name}".
+    /// ESPHome climate object ID used by Home Assistant.
+    /// Defaults to "climate.{node_name}".
     pub object_id: Option<String>,
 
-    /// Listen address for ESP Home API server, default "0.0.0.0:6053"
+    /// Bind address for the ESPHome Native API server.
+    /// Defaults to "0.0.0.0:6053", which listens on all IPv4 interfaces.
     pub listen_addr: String,
 
-    /// Encryption key as 32 byte base64 string. When not provided, the
-    /// connection uses plaintext messages.
+    /// ESPHome Noise encryption key as a base64-encoded 32-byte value.
+    /// When not provided, the connection uses plaintext messages. The same key
+    /// must be supplied to Home Assistant.
     /// See [ESP Home Native API](https://esphome.io/components/api/)
     /// for a tool that generates a random key.
     pub encryption_key: Option<String>,
@@ -155,19 +159,22 @@ pub struct HomeAssistantConfig {
     /// Defaults to "ReTherm {version}".
     pub server_info: String,
 
-    /// Node name, defaults to the system hostname
+    /// ESPHome node name. Defaults to the system hostname, or "retherm" if the
+    /// hostname cannot be read.
     pub node_name: Option<String>,
 
-    /// Friendly name displayed in as label for thermostat control
+    /// Friendly device name displayed in Home Assistant.
+    /// Defaults to "ReTherm Thermostat".
     pub friendly_name: String,
 
-    /// Manufactuer name, defaults to "Nest"
+    /// Manufacturer name, defaults to "Nest".
     pub manufacturer: String,
 
-    /// Model name, defaults to "Gen2 Thermostat"
+    /// Model name, defaults to "Gen2 Thermostat".
     pub model: String,
 
-    /// Mac address, defaults to address of system interface address
+    /// MAC address, defaults to an address found on a system interface. A
+    /// fallback value is used if no address can be read.
     pub mac_address: Option<String>
 }
 
@@ -303,7 +310,7 @@ impl Default for AwayConfig {
 /// [backplate]
 /// near_pir_threshold = 15
 /// serial_port = "/dev/ttyO2"
-/// wiring = { heat_wire: "W1", cool_wire: "Y1" }
+/// wiring = { type = "HeatAndCool", heat_wire = "W1", cool_wire = "Y1", fan_wire = "G" }
 /// ```
 #[derive(Deserialize, Debug, Clone)]
 #[serde(default)]
@@ -314,7 +321,8 @@ pub struct BackplateConfig {
     /// Path to backplate serial device file, default "/dev/ttyO2"
     pub serial_port: String,
 
-    /// HVAC wiring configuration, default `{ heat_wire: "W1", cool_wire: "Y1" }`.
+    /// HVAC wiring configuration. Defaults to
+    /// `{ type = "HeatAndCool", heat_wire = "W1", cool_wire = "Y1", fan_wire = "G" }`.
     /// Valid wire names: W1, Y1, G, OB, W2, Y2, Star.
     pub wiring: WireConfig
 }

--- a/src/config/schedule_config.rs
+++ b/src/config/schedule_config.rs
@@ -37,7 +37,7 @@ use super::config_de;
 ///
 /// You can define more than one schedule entry, and it will overlap the
 /// previous. In the example below, the temperature will be set to 20.0
-/// at 8am everyday, and set down to 16.0 at 9am Monday and Wednsday.
+/// at 8am every day, and set down to 16.0 at 9am Monday and Wednesday.
 ///
 /// ```toml
 /// [[schedule_heat]]
@@ -47,7 +47,7 @@ use super::config_de;
 /// ]
 ///
 /// [[schedule_heat]]
-/// days_of_week = ["Monday", "Wednsday"]
+/// days_of_week = ["Mon", "Wed"]
 /// set_points = [
 ///    { time = "09:00", temp = 16.0 }
 /// ]
@@ -60,7 +60,7 @@ pub struct ScheduleConfig {
     ///
     /// Or...
     ///
-    /// List of weekdays ["Monday", "Tuesday", ...]
+    /// List of weekday values: "Mon", "Tue", "Wed", "Thur", "Fri", "Sat", "Sun".
     pub days_of_week: DaysOfWeek,
 
     /// List of set points with time of day and temperature

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -17,8 +17,8 @@ content = "Dial interface similar to stock Nest UI with mode select"
 [[extra.list]]
 title = "Home Assistant"
 content = '''
-Integrates with <a href="configuration#home-assistant">Home Assistant</a>
-seamlessly using ESPHome API, no additional services required'''
+Connect <a href="/home-assistant/">Home Assistant</a> directly to ReTherm on the
+thermostat using the ESPHome Native API; no cloud API, MQTT, or bridge required'''
 
 [[extra.list]]
 title = "Away mode"

--- a/website/content/configuration.md
+++ b/website/content/configuration.md
@@ -8,6 +8,24 @@ toc = true
 # DO NOT EDIT
 # Use `make_docs.sh` to generate content
 +++
+
+The supplied init script always loads `/retherm/config.toml`. The file must
+exist even though every setting inside it is optional. A minimal working file
+is:
+
+```toml
+[home_assistant]
+friendly_name = "Hallway Nest"
+node_name = "hallway-nest"
+```
+
+See [Home Assistant](/home-assistant/) for the connection procedure and optional
+ESPHome Noise encryption. The complete generated setting reference follows.
+
+Duration fields accept an integer number of seconds or a string ending in `s`
+or `m`, such as `30s` or `5m`. The current parser rejects `h`-suffixed values;
+express hours as minutes instead.
+
 # Config file
 
 Launch retherm with the path to your custom configuration.
@@ -39,7 +57,9 @@ Defaults to 0.4
 
 ## min_off_time
 
-Minimum off time for cooling to allow AC refrigerant pressures to equalize.
+Minimum idle time before ReTherm energizes a new HVAC action. This also
+provides compressor protection by allowing refrigerant pressures to
+equalize.
 
 Defaults to "5m"
 
@@ -83,7 +103,7 @@ or set to zero to disable away mode. Default "30m".
 [backplate]
 near_pir_threshold = 15
 serial_port = "/dev/ttyO2"
-wiring = { heat_wire: "W1", cool_wire: "Y1" }
+wiring = { type = "HeatAndCool", heat_wire = "W1", cool_wire = "Y1", fan_wire = "G" }
 ```
 
 ## near_pir_threshold
@@ -96,7 +116,8 @@ Path to backplate serial device file, default "/dev/ttyO2"
 
 ## wiring
 
-HVAC wiring configuration, default `{ heat_wire: "W1", cool_wire: "Y1" }`.
+HVAC wiring configuration. Defaults to
+`{ type = "HeatAndCool", heat_wire = "W1", cool_wire = "Y1", fan_wire = "G" }`.
 Valid wire names: W1, Y1, G, OB, W2, Y2, Star.
 
 # Home Assistant
@@ -109,17 +130,19 @@ encryption_key = "..."
 
 ## object_id
 
-Object ID used internall by home assistant.
-Defaults to "climage.{node_name}".
+ESPHome climate object ID used by Home Assistant.
+Defaults to "climate.{node_name}".
 
 ## listen_addr
 
-Listen address for ESP Home API server, default "0.0.0.0:6053"
+Bind address for the ESPHome Native API server.
+Defaults to "0.0.0.0:6053", which listens on all IPv4 interfaces.
 
 ## encryption_key
 
-Encryption key as 32 byte base64 string. When not provided, the
-connection uses plaintext messages.
+ESPHome Noise encryption key as a base64-encoded 32-byte value.
+When not provided, the connection uses plaintext messages. The same key
+must be supplied to Home Assistant.
 See [ESP Home Native API](https://esphome.io/components/api/)
 for a tool that generates a random key.
 
@@ -130,23 +153,26 @@ Defaults to "ReTherm {version}".
 
 ## node_name
 
-Node name, defaults to the system hostname
+ESPHome node name. Defaults to the system hostname, or "retherm" if the
+hostname cannot be read.
 
 ## friendly_name
 
-Friendly name displayed in as label for thermostat control
+Friendly device name displayed in Home Assistant.
+Defaults to "ReTherm Thermostat".
 
 ## manufacturer
 
-Manufactuer name, defaults to "Nest"
+Manufacturer name, defaults to "Nest".
 
 ## model
 
-Model name, defaults to "Gen2 Thermostat"
+Model name, defaults to "Gen2 Thermostat".
 
 ## mac_address
 
-Mac address, defaults to address of system interface address
+MAC address, defaults to an address found on a system interface. A
+fallback value is used if no address can be read.
 
 # Backlight
 
@@ -180,7 +206,7 @@ set_points = [
 
 You can define more than one schedule entry, and it will overlap the
 previous. In the example below, the temperature will be set to 20.0
-at 8am everyday, and set down to 16.0 at 9am Monday and Wednsday.
+at 8am every day, and set down to 16.0 at 9am Monday and Wednesday.
 
 ```toml
 [[schedule_heat]]
@@ -190,7 +216,7 @@ set_points = [
 ]
 
 [[schedule_heat]]
-days_of_week = ["Monday", "Wednsday"]
+days_of_week = ["Mon", "Wed"]
 set_points = [
    { time = "09:00", temp = 16.0 }
 ]
@@ -204,9 +230,8 @@ One of "EveryDay", "WeekDays", "WeekEnd"
 
 Or...
 
-List of weekdays ["Monday", "Tuesday", ...]
+List of weekday values: "Mon", "Tue", "Wed", "Thur", "Fri", "Sat", "Sun".
 
 ## set_points
 
 List of set points with time of day and temperature
-

--- a/website/content/configuration.tmpl
+++ b/website/content/configuration.tmpl
@@ -8,3 +8,20 @@ toc = true
 # DO NOT EDIT
 # Use `make_docs.sh` to generate content
 +++
+
+The supplied init script always loads `/retherm/config.toml`. The file must
+exist even though every setting inside it is optional. A minimal working file
+is:
+
+```toml
+[home_assistant]
+friendly_name = "Hallway Nest"
+node_name = "hallway-nest"
+```
+
+See [Home Assistant](/home-assistant/) for the connection procedure and optional
+ESPHome Noise encryption. The complete generated setting reference follows.
+
+Duration fields accept an integer number of seconds or a string ending in `s`
+or `m`, such as `30s` or `5m`. The current parser rejects `h`-suffixed values;
+express hours as minutes instead.

--- a/website/content/home-assistant.md
+++ b/website/content/home-assistant.md
@@ -1,0 +1,116 @@
++++
+title = "Home Assistant"
+template = "docgen.html"
+
+[extra]
+toc = true
++++
+
+## Architecture
+
+ReTherm runs directly on the rooted Nest thermostat. While it is running, it
+replaces the stock Nest application and exposes an ESPHome Native API server
+from the thermostat itself.
+
+```text
++----------------+       ESPHome Native API        +--------------------------+
+| Home Assistant | ------------------------------> | ReTherm on the rooted Nest|
+|                |          TCP 6053               | Gen 2 thermostat          |
++----------------+                                  +--------------------------+
+```
+
+Home Assistant does **not** communicate with Google's Nest API, the stock Nest
+application, NoLongerEvil's Home Assistant integration, or MQTT. No separate
+ESPHome device or broker is involved.
+
+## Connect Home Assistant
+
+ReTherm listens for ESPHome Native API connections on TCP port 6053 by default.
+It does not currently implement mDNS/zeroconf discovery, so add it manually by
+IP address:
+
+1. Start ReTherm on the thermostat.
+2. Determine the thermostat's IP address from your router's DHCP client list.
+   On the thermostat, `ifconfig` can also show the IPv4 address; the wireless
+   interface name depends on the installed root environment.
+3. In Home Assistant, go to **Settings → Devices & services → Add Integration →
+   ESPHome**.
+4. Enter the thermostat's IP address.
+5. Use port `6053` unless you changed `home_assistant.listen_addr` in
+   `/retherm/config.toml`.
+6. If `home_assistant.encryption_key` is not configured, leave encryption and
+   password fields blank. ReTherm does not configure an API password.
+7. If encryption is configured, enter the same encryption key in Home
+   Assistant.
+8. Complete the integration.
+
+The configured default `0.0.0.0` is ReTherm's server bind address; do not enter
+`0.0.0.0` in Home Assistant. Enter the thermostat's actual IP address.
+
+Use a stable DHCP lease or address reservation if the thermostat's IP address
+can change. Give each ReTherm thermostat a unique `node_name`.
+
+## What appears in Home Assistant
+
+ReTherm exposes one climate entity. Its displayed device/friendly name follows
+`home_assistant.node_name` and `home_assistant.friendly_name`; Home Assistant
+derives the final entity ID, so this guide does not assume a fixed one.
+
+The climate entity reports:
+
+- current temperature;
+- target temperature;
+- mode: `off`, `heat`, `cool`, or `fan only`;
+- HVAC action: `idle`, `heating`, `cooling`, or `fan`; and
+- preset: `none` or `away`.
+
+Home Assistant can set the target temperature, change between the four modes,
+and enable or clear the away preset. ReTherm advertises a 9–32 °C visual range
+with 0.5 °C display steps. Fan-only mode uses ReTherm's configured fan timer;
+it is a climate mode, not a separately exposed fan entity.
+
+## Plaintext configuration (default)
+
+```toml
+[home_assistant]
+friendly_name = "Hallway Nest"
+node_name = "hallway-nest"
+```
+
+With no `encryption_key`, ReTherm uses plaintext ESPHome Native API messages.
+The connection still stays on the network path between Home Assistant and the
+thermostat, but it is not encrypted at the ESPHome protocol layer.
+
+## Optional ESPHome encryption
+
+ReTherm supports ESPHome Native API Noise encryption with a base64-encoded
+32-byte pre-shared key:
+
+```toml
+[home_assistant]
+friendly_name = "Hallway Nest"
+node_name = "hallway-nest"
+encryption_key = "<base64 ESPHome Noise PSK>"
+```
+
+For example, generate a key on a trusted computer with:
+
+```sh
+openssl rand -base64 32
+```
+
+Restart ReTherm after changing the file:
+
+```sh
+/etc/init.d/retherm restart
+```
+
+Supply exactly the same key when Home Assistant asks for the ESPHome encryption
+key. A missing, malformed, or mismatched key prevents the connection. Changing
+encryption settings does not change the default TCP port.
+
+See [Configuration](/configuration/) for all ESPHome server naming and listen
+options, or [Troubleshooting](/troubleshooting/) if the connection fails. The
+[Home Assistant ESPHome integration documentation](https://www.home-assistant.io/integrations/esphome/)
+describes the current integration dialog and its Host, Port, Noise PSK, and
+deprecated Password fields.

--- a/website/content/install.md
+++ b/website/content/install.md
@@ -6,68 +6,155 @@ template = "docgen.html"
 toc = true
 +++
 
-> At this time, the installation process expects you to have a rooted thermostat
-> and familiarity with the Linux command line.
+ReTherm runs directly on a rooted second-generation Nest Thermostat and takes
+over the thermostat UI and HVAC control path while it is running. It is not a
+plugin for the stock Nest application.
 
-## Get root
+> ReTherm does not configure Wi-Fi. Before stopping the stock application,
+> confirm that the thermostat is on the correct network and that you can log in
+> over SSH. Keep the recovery commands below available.
 
-You'll need a rooted Nest with SSH access. Any of the following methods should work.
+## Prerequisites
 
-* [NestDFUAttack](https://github.com/exploiteers/NestDFUAttack)
-* [Cuckoo Loader](https://github.com/cuckoo-nest/cuckoo_loader)
-* [NoLongerEvil](https://nolongerevil.com/)
+- A rooted Nest Gen 2 thermostat with working SSH access. Rooting methods
+  include [NestDFUAttack](https://github.com/exploiteers/NestDFUAttack),
+  [Cuckoo Loader](https://github.com/cuckoo-nest/cuckoo_loader), and
+  [NoLongerEvil](https://nolongerevil.com/).
+- The thermostat and Home Assistant on networks that can reach each other.
+- A current ReTherm binary from the
+  [GitHub Releases page](https://github.com/jiggak/retherm/releases), or a binary
+  built from source as described in the project
+  [README](https://github.com/jiggak/retherm).
 
-## Download & Install
+The commands below run on the thermostat over SSH unless noted otherwise.
 
-I'll assume retherm will be placed under `/retherm/`, but choose whatever
-directory you like.
+## 1. Install ReTherm
 
-Go to the [Releases](https://github.com/jiggak/retherm/releases) page on Github
-and copy the latest download link.
+Create the application directory:
 
-If you prefer to build ReTherm yourself, details are in the project
-[README](https://github.com/jiggak/retherm).
+```sh
+mkdir -p /retherm
+```
 
-1. Make directory for ReTherm if it doesn't already exist
-   ```bash
-   mkdir /retherm
-   ```
-2. Download latest build
-   ```bash
-   # Replace download link with one copied from releases page.
-   # Make sure retherm is stopped before replacing (when updating, not installing first time).
-   curl -o /retherm/retherm https://github.com/jiggak/retherm/releases/download/v1.0.0/retherm
-   chmod +x /retherm/retherm
-   ```
-3. Create `/etc/init.d/retherm` with contents of [init.sh](https://github.com/jiggak/retherm/blob/main/init.sh)
-   ```bash
-   curl -o /etc/init.d/retherm https://raw.githubusercontent.com/jiggak/retherm/refs/heads/main/init.sh
-   chmod +x /etc/init.d/retherm
-   ```
-4. Stop Nest app `/etc/init.d/nestlabs stop`
-5. Start ReTherm `/etc/init.d/retherm start`
+Download a release. Replace `<VERSION>` with the release tag you selected:
 
-ReTherm will run until the device reboots; the default Nest app will start the
-next time the device reboots.
+```sh
+curl -L -o /retherm/retherm \
+  https://github.com/jiggak/retherm/releases/download/<VERSION>/retherm
+chmod +x /retherm/retherm
+```
 
-> Currently ReTherm doesn't have an interface for configuring Wifi.
-> It's crutial the Nest app starts at boot so that you maintain some means
-> to set network settings (i.e. SSH access).
+You can instead copy the binary from another computer with `scp`; the required
+destination is `/retherm/retherm` when using the supplied init script.
+
+## 2. Install the init script
+
+```sh
+curl -L -o /etc/init.d/retherm \
+  https://raw.githubusercontent.com/jiggak/retherm/refs/heads/main/init.sh
+chmod +x /etc/init.d/retherm
+```
+
+The script starts this exact command in the background:
+
+```sh
+/retherm/retherm --config /retherm/config.toml --syslog INFO
+```
+
+Consequently, both `/retherm/retherm` and `/retherm/config.toml` are required.
+
+## 3. Create the configuration
+
+Download the working example:
+
+```sh
+curl -L -o /retherm/config.toml \
+  https://raw.githubusercontent.com/jiggak/retherm/refs/heads/main/config.example.toml
+```
+
+Edit `friendly_name` and `node_name` for the thermostat. The minimal file is:
+
+```toml
+[home_assistant]
+friendly_name = "Hallway Nest"
+node_name = "hallway-nest"
+```
+
+Every setting has a default, but the init script still requires the file to
+exist. The default ESPHome Native API endpoint is `0.0.0.0:6053` and encryption
+is off unless `encryption_key` is configured. See [Configuration](/configuration/)
+before changing the listen address, HVAC wiring, or other defaults.
+
+## 4. Stop Nest and start ReTherm
+
+```sh
+/etc/init.d/nestlabs stop
+/etc/init.d/retherm start
+```
+
+Stopping `nestlabs` releases the thermostat UI/control path. Starting ReTherm
+then replaces that application for as long as ReTherm is running; the two are
+not intended to operate together.
+
+## 5. Verify startup
+
+Confirm the process exists:
+
+```sh
+pidof retherm
+```
+
+Confirm that the default ESPHome port is listening:
+
+```sh
+netstat -ltn | grep 6053
+```
+
+The init script sends INFO-level logs to syslog. Inspect recent messages with:
+
+```sh
+tail /var/log/messages
+```
+
+If you changed `listen_addr`, check its configured port instead. Then follow
+the [Home Assistant setup guide](/home-assistant/).
+
+## 6. Test before changing startup behavior
+
+From Home Assistant, confirm that the current temperature updates and test each
+HVAC mode your system uses. Verify the physical equipment behaves correctly.
+
+The supplied init script does not register ReTherm to start automatically, and
+this guide intentionally leaves the stock Nest application as the reboot
+default. ReTherm currently has no Wi-Fi settings UI; keeping the stock boot path
+reduces the chance of losing network and SSH access. Only change the thermostat's
+boot configuration after you have a tested recovery method appropriate to your
+rooting environment.
+
+## Return to the stock Nest application
+
+Stop ReTherm before restarting the stock application:
+
+```sh
+/etc/init.d/retherm stop
+/etc/init.d/nestlabs start
+```
+
+This returns the display and thermostat control path to the normal Nest
+software. If ReTherm was only started manually as described above, rebooting
+also returns to the stock boot behavior.
 
 ## Logging to syslogd
 
-Optionally, ReTherm can output logs to `syslogd`. Log messages will be written
-to `/var/log/messages`.
+The supplied init script already launches ReTherm with `--syslog INFO`, writing
+to `/var/log/messages`. Valid log levels are `OFF`, `ERROR`, `WARN`, `INFO`,
+`DEBUG`, and `TRACE`.
 
-```console
-# INFO can be one of: TRACE, DEBUG, INFO, ERROR
-retherm --syslog INFO
-```
+For remote log forwarding, append the appropriate remote option to
+`/etc/syslogd.options`; for example, where `192.168.1.42` is the log server:
 
-This opens up the option to forwarding log messages to a log collector by appending
-`-R 192.168.1.42:514 -L` to `/etc/syslogd.options` where "192.168.1.42" is the
-address of your log server.
-
-```
+```text
 -O /var/log/messages -s 384 -b 15 -u -R 192.168.1.42:514 -L
 ```
+
+See [Troubleshooting](/troubleshooting/) for startup and connection checks.

--- a/website/content/troubleshooting.md
+++ b/website/content/troubleshooting.md
@@ -1,0 +1,87 @@
++++
+title = "Troubleshooting"
+template = "docgen.html"
+
+[extra]
+toc = true
++++
+
+## Home Assistant cannot connect
+
+On the thermostat, confirm that ReTherm is running:
+
+```sh
+pidof retherm
+```
+
+Confirm that the configured ESPHome Native API port is listening. The default
+is 6053:
+
+```sh
+netstat -ltn | grep 6053
+```
+
+Then check:
+
+- Home Assistant is using the thermostat's current IP address.
+- The Home Assistant host can route to the thermostat's network and no firewall
+  blocks the configured TCP port.
+- `home_assistant.listen_addr` and the port entered in Home Assistant agree.
+- Home Assistant has the exact `encryption_key` from `/retherm/config.toml`, or
+  both sides are configured without encryption.
+- The stock application was stopped with `/etc/init.d/nestlabs stop` before
+  ReTherm was started.
+
+The supplied init script logs to `/var/log/messages`:
+
+```sh
+tail /var/log/messages
+```
+
+Look for `Listening for HA connection` or an error binding the listen address.
+
+## The ESPHome device does not appear automatically
+
+This is expected. ReTherm does not currently implement mDNS/zeroconf discovery.
+In Home Assistant, use **Settings → Devices & services → Add Integration →
+ESPHome**, then enter the thermostat's IP address and configured port manually.
+
+## ReTherm fails to start
+
+The supplied init script requires these exact paths:
+
+```text
+/retherm/retherm
+/retherm/config.toml
+```
+
+Check that both files exist and the binary and init script are executable:
+
+```sh
+ls -l /retherm/retherm /retherm/config.toml /etc/init.d/retherm
+```
+
+Common causes are invalid TOML syntax, an invalid value or value type, an
+unreadable configuration file, a missing `/media/data` storage directory, an
+invalid base64 encryption key, or device/backplate resources still held by the
+stock Nest application. Review `/var/log/messages` for the specific error.
+
+To isolate an init-script problem, run the same command in the foreground and
+read its error output:
+
+```sh
+/retherm/retherm --config /retherm/config.toml
+```
+
+Stop that foreground process before starting ReTherm through the init script.
+
+## Recover the stock thermostat UI
+
+```sh
+/etc/init.d/retherm stop
+/etc/init.d/nestlabs start
+```
+
+Always stop one application before starting the other. If the manual install
+procedure was followed without changing boot registration, a reboot restores
+the stock application's normal boot behavior.

--- a/website/zola.toml
+++ b/website/zola.toml
@@ -25,9 +25,9 @@ url = "/configuration/"
 weight = 10
 
 [[extra.menu.main]]
-name = "Theme"
-section = "theme"
-url = "/theme/"
+name = "Home Assistant"
+section = "home-assistant"
+url = "/home-assistant/"
 weight = 20
 
 [[extra.menu.main]]
@@ -35,6 +35,18 @@ name = "Install"
 section = "install"
 url = "/install/"
 weight = 30
+
+[[extra.menu.main]]
+name = "Troubleshooting"
+section = "troubleshooting"
+url = "/troubleshooting/"
+weight = 40
+
+[[extra.menu.main]]
+name = "Theme"
+section = "theme"
+url = "/theme/"
+weight = 50
 
 [[extra.menu.social]]
 name = "GitHub"


### PR DESCRIPTION
Significantly improves user documentation with new guides for Home Assistant integration and troubleshooting. Adds config.example.toml as a working starting point and restructures the README with clearer installation and development sections. Clarifies configuration comments and fixes documentation typos and outdated examples.