### PR TITLE
Document Home Assistant ESPHome setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Home Assistant setup.
 This project aims to provide a completely new UI for a rooted Gen 2 Nest
 Thermostat.
 
+## Home Assistant
+
+ReTherm exposes an ESPHome Native API interface directly from the thermostat,
+allowing Home Assistant to connect without Google's Nest API or MQTT. See the
+[installation guide](https://retherm.kropf.io/install/#connect-home-assistant-with-esphome)
+for setup instructions.
+
 ## Highlevel list of features for MVP
 
 - [x] Bi-directional Home Assistant connection using esphome API

--- a/website/content/install.md
+++ b/website/content/install.md
@@ -44,8 +44,16 @@ If you prefer to build ReTherm yourself, details are in the project
    curl -o /etc/init.d/retherm https://raw.githubusercontent.com/jiggak/retherm/refs/heads/main/init.sh
    chmod +x /etc/init.d/retherm
    ```
-4. Stop Nest app `/etc/init.d/nestlabs stop`
-5. Start ReTherm `/etc/init.d/retherm start`
+4. Create `/retherm/config.toml`. The supplied init script requires this file.
+   A minimal Home Assistant configuration is:
+   ```toml
+   [home_assistant]
+   friendly_name = "Hallway Nest"
+   node_name = "hallway-nest"
+   ```
+5. Stop Nest app `/etc/init.d/nestlabs stop`
+6. Start ReTherm `/etc/init.d/retherm start`
+7. Add the thermostat to Home Assistant using the instructions below.
 
 ReTherm will run until the device reboots; the default Nest app will start the
 next time the device reboots.
@@ -53,6 +61,35 @@ next time the device reboots.
 > Currently ReTherm doesn't have an interface for configuring Wifi.
 > It's crutial the Nest app starts at boot so that you maintain some means
 > to set network settings (i.e. SSH access).
+
+## Connect Home Assistant with ESPHome
+
+ReTherm runs an ESPHome Native API server directly on the thermostat:
+
+```text
+Home Assistant -- ESPHome Native API (TCP 6053) --> ReTherm on the Nest
+```
+
+Home Assistant connects to the thermostat's IP address. This does not use
+Google's Nest API, the stock Nest application, NoLongerEvil's Home Assistant
+integration, MQTT, or a separate ESPHome device.
+
+ReTherm does not currently provide mDNS/zeroconf discovery, so add it manually:
+
+1. Make sure ReTherm is running on the thermostat.
+2. Find the thermostat's IP address in your router's DHCP client list.
+3. In Home Assistant, go to **Settings → Devices & services → Add Integration →
+   ESPHome**.
+4. Enter the thermostat's IP address as the host.
+5. Use port `6053` unless `home_assistant.listen_addr` was changed in
+   `/retherm/config.toml`.
+6. Leave the password blank. Leave the Noise PSK blank unless encryption was
+   configured; if it was, enter the same key used by ReTherm.
+7. Complete the integration.
+
+`0.0.0.0` in the default listen address means that ReTherm listens on every
+network interface. Enter the thermostat's actual IP address in Home Assistant,
+not `0.0.0.0`.
 
 ## Logging to syslogd
 


### PR DESCRIPTION
This change adds Home Assistant setup documentation to the main README and installation guide. It explains how to create /retherm/config.toml, start ReTherm, and connect Home Assistant to the thermostat over ESPHome Native API on port 6053, including the default listen address caveat.